### PR TITLE
MIME type of blob

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default function workerize(code, options) {
 	let exportsObjName = `__xpo${Math.random().toString().substring(2)}__`;
 	if (typeof code==='function') code = `(${Function.prototype.toString.call(code)})(${exportsObjName})`;
 	code = toCjs(code, exportsObjName, exports) + `\n(${Function.prototype.toString.call(setup)})(self,${exportsObjName},{})`;
-	let url = URL.createObjectURL(new Blob([code])),
+	let url = URL.createObjectURL(new Blob([code], {type: 'application/javascript'})),
 		worker = new Worker(url, options),
 		term = worker.terminate,
 		callbacks = {},


### PR DESCRIPTION
Trying to use a "module"-type worker results in MIME type rejection:
`Failed to load module script: The server responded with a non-JavaScript MIME type of "". Strict MIME type checking is enforced for module scripts per HTML spec.`